### PR TITLE
Fixed errors in URLs with HTML escaped characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ After installing, invoke it a first time with `scrap config` in order to make th
 After uninstalling, the global configuration file (stored under the user profile folder at `.scrap/scrap-user.json`) will NOT be deleted.
 
 ## Configuration and usage
-Please head to the [wiki page](https://github.com/icalvo/scrap/wiki) to find documentaion on configuration and usage.
+Please head to the [wiki page](https://github.com/icalvo/scrap/wiki) to find documentation on configuration and usage.

--- a/src/.idea/.idea.scrap/.idea/misc.xml
+++ b/src/.idea/.idea.scrap/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
-</project>

--- a/src/.idea/.idea.scrap/.idea/vcs.xml
+++ b/src/.idea/.idea.scrap/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/src/.idea/.idea.scrap/.idea/vcs.xml
+++ b/src/.idea/.idea.scrap/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/src/Domain/Pages/Page.cs
+++ b/src/Domain/Pages/Page.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.XPath;
+﻿using System.Net;
+using System.Xml.XPath;
 using Microsoft.Extensions.Logging;
 
 namespace Scrap.Domain.Pages;
@@ -70,7 +71,7 @@ public class Page: IPage
         var nodesEnumerable = ToEnumerable(_navigator.Select(xPath));
         var results = xPath.IsHtml
             ? nodesEnumerable.Select(x => x.InnerXml)
-            : nodesEnumerable.Select(x => x.Value);
+            : nodesEnumerable.Select(x => WebUtility.HtmlDecode(x.Value));
         var resultsArray = results
             .RemoveNulls()
             .Where(url => !string.IsNullOrEmpty(url))


### PR DESCRIPTION
URLS coming from HTML with escaped entities (e.g. &#039;) are invalid. To fix it we are HTML decoding texts except if the `html:` prefix is used.